### PR TITLE
Enable experimental modules on older Node version

### DIFF
--- a/src/cyberchef/bin/package.json
+++ b/src/cyberchef/bin/package.json
@@ -22,6 +22,7 @@
     "url": "https://github.com/NDietrich/CyberChef-for-Splunk.git"
   },
   "private": true,
+  "type": "module",
   "dependencies": {
     "csv-parse": "^4.14.1",
     "csv-stringify": "~5.4.0",


### PR DESCRIPTION
Adding "type":"module" to packages.json helps to resolve issue with enabling ESM experimental modules (import/export).

Symptom: cyberchef SPL errors with unexpected keyword "export"

Setup: RHEL 7, Splunk 8.1.2